### PR TITLE
Parallel gets of pending shards to trie

### DIFF
--- a/.scalog.yaml
+++ b/.scalog.yaml
@@ -37,3 +37,4 @@ metadata-trim-frequency: 2000 # ms
 
 async-trie-update: true
 disable-logs: true
+parallel-bulk-aync-update: false

--- a/zookeeper/metadata.go
+++ b/zookeeper/metadata.go
@@ -295,6 +295,18 @@ func (md *Metadata) FetchShardId(gsn int64) (int32, error) {
 	return -1, errors.New("Invalid gsn")
 }
 
+/* Bulk fetch all from current GSN to latest */
+func (md *Metadata) FetchPendingShards(gsn int64) map[int64]int32 {
+	data := make(map[int64]int32)
+	for _, item := range md.items {
+		if item.GSN >= gsn {
+			data[item.GSN] = item.shardId
+		}
+	}
+
+	return data
+}
+
 func (md *Metadata) TrimMetadata() {
 	interval := time.Duration(int(viper.GetInt("metadata-trim-frequency"))) * time.Millisecond
 	ticker := time.NewTicker(interval)

--- a/zookeeper/metadata.go
+++ b/zookeeper/metadata.go
@@ -297,6 +297,8 @@ func (md *Metadata) FetchShardId(gsn int64) (int32, error) {
 
 /* Bulk fetch all from current GSN to latest */
 func (md *Metadata) FetchPendingShards(gsn int64) map[int64]int32 {
+	md.RLock()
+	defer md.RUnlock()
 	data := make(map[int64]int32)
 	for _, item := range md.items {
 		if item.GSN >= gsn {

--- a/zookeeper/zk.go
+++ b/zookeeper/zk.go
@@ -58,61 +58,94 @@ type GSN_OP_Pair struct {
 func (zk *Zookeeper) CheckAndUpdateTrie() {
 	sleepForIfNoUpdate := time.Duration(int(viper.GetInt("zk-sleep-if-no-update"))) * time.Millisecond
 	var wg sync.WaitGroup
-	for {
-		zk.Lock()
-		nextOpAt := zk.consensus.LSN
-		gsn_shard_map := zk.consensus.metadata.FetchPendingShards(nextOpAt)
 
-		if len(gsn_shard_map) == 0 {
-			log.Printf("[ Zookeeper ][ UpdateTrie ]No new update to apply;")
-			time.Sleep(sleepForIfNoUpdate)
+	parallel_bulk := true
+
+	if parallel_bulk == true {
+		for {
+			zk.Lock()
+			nextOpAt := zk.consensus.LSN
+			gsn_shard_map := zk.consensus.metadata.FetchPendingShards(nextOpAt)
+
+			if len(gsn_shard_map) == 0 {
+				log.Printf("[ Zookeeper ][ UpdateTrie ]No new update to apply;")
+				time.Sleep(sleepForIfNoUpdate)
+				zk.Unlock()
+				continue
+			}
+
+			outputCh := make(chan GSN_OP_Pair, len(gsn_shard_map))
+
+			for gsn, shard := range gsn_shard_map {
+				wg.Add(1)
+
+				go func(gsn int64, shard int32) {
+					defer wg.Done()
+					op, err := zk.consensus.ReadFromLog(gsn, shard)
+					if err != nil {
+						log.Printf("[ Zookeeper ][ UpdateTrie ]Reading operation from log failed for lsn: %v at sid: %v with error: %v", gsn, shard, err)
+						// zk.Unlock()
+						return
+					}
+					zk.consensus.metadata.UpdateEntryState(gsn)
+					if len(op) != 0 {
+						// Successfully fetched the operation, send it to the output channel
+						message := GSN_OP_Pair{GSN: gsn, op: op}
+						outputCh <- message
+					}
+				}(gsn, shard)
+			}
+
+			// goroutine to wait for all requests to finish
+			go func() {
+				wg.Wait()
+				close(outputCh)
+			}()
+			// Channels cannot be sorted so hold it in another var first
+			var pairs []GSN_OP_Pair
+			for pair := range outputCh {
+				pairs = append(pairs, pair)
+			}
+			// Sorting the slice by GSN - so that ops can be performed in-order
+			sort.Slice(pairs, func(i, j int) bool {
+				return pairs[i].GSN < pairs[j].GSN
+			})
+			for _, pair := range pairs {
+				log.Printf("[ Zookeeper ][ UpdateTrie ]Updating trie with operation: %v LSN: %v", pair.op, zk.consensus.LSN)
+				zk.trie.Execute(pair.op)
+				zk.consensus.IncrementLSN()
+			}
+
 			zk.Unlock()
-			continue
+			time.Sleep(sleepForIfNoUpdate)
 		}
+	} else {
+		for {
+			zk.Lock()
+			nextOpAt := zk.consensus.LSN
+			shardId, err := zk.consensus.metadata.FetchShardId(nextOpAt)
 
-		outputCh := make(chan GSN_OP_Pair, len(gsn_shard_map))
+			if err != nil {
+				log.Printf("[ Zookeeper ][ UpdateTrie ]No new update to apply; %v", err)
+				time.Sleep(sleepForIfNoUpdate)
+				zk.Unlock()
+				continue
+			}
 
-		for gsn, shard := range gsn_shard_map {
-			wg.Add(1)
+			op, err := zk.consensus.ReadFromLog(nextOpAt, shardId)
+			if err != nil {
+				log.Printf("[ Zookeeper ][ UpdateTrie ]Reading operation from log failed for lsn: %v at sid: %v with error: %v", nextOpAt, shardId, err)
+				zk.Unlock()
+				continue
+			}
 
-			go func(gsn int64, shard int32) {
-				defer wg.Done()
-				op, err := zk.consensus.ReadFromLog(gsn, shard)
-				if err != nil {
-					log.Printf("[ Zookeeper ][ UpdateTrie ]Reading operation from log failed for lsn: %v at sid: %v with error: %v", gsn, shard, err)
-					zk.Unlock()
-					return
-				}
-				zk.consensus.metadata.UpdateEntryState(gsn)
-				if len(op) != 0 {
-					// Successfully fetched the operation, send it to the output channel
-					message := GSN_OP_Pair{GSN: gsn, op: op}
-					outputCh <- message
-				}
-			}(gsn, shard)
-		}
-
-		// goroutine to wait for all requests to finish
-		go func() {
-			wg.Wait()
-			close(outputCh)
-		}()
-		// Channels cannot be sorted so hold it in another var first
-		var pairs []GSN_OP_Pair
-		for pair := range outputCh {
-			pairs = append(pairs, pair)
-		}
-		// Sorting the slice by GSN - so that ops can be performed in-order
-		sort.Slice(pairs, func(i, j int) bool {
-			return pairs[i].GSN < pairs[j].GSN
-		})
-		for _, pair := range pairs {
-			log.Printf("[ Zookeeper ][ UpdateTrie ]Updating trie with operation: %v LSN: %v", pair.op, zk.consensus.LSN)
-			zk.trie.Execute(pair.op)
+			log.Printf("[ Zookeeper ][ UpdateTrie ]Updating trie with operation: %v", op)
+			zk.trie.Execute(op)
+			zk.consensus.metadata.UpdateEntryState(nextOpAt)
 			zk.consensus.IncrementLSN()
+			zk.Unlock()
+			time.Sleep(sleepForIfNoUpdate)
 		}
-
-		zk.Unlock()
 	}
 }
 

--- a/zookeeper/zk.go
+++ b/zookeeper/zk.go
@@ -4,6 +4,7 @@ import (
 	context "context"
 	"fmt"
 	"net"
+	"sort"
 	"sync"
 	"time"
 
@@ -49,33 +50,69 @@ func (zk *Zookeeper) GetShardIdMapping(gsn int64) (int32, error) {
 	return sid, nil
 }
 
+type GSN_OP_Pair struct {
+	GSN int64
+	op  string
+}
+
 func (zk *Zookeeper) CheckAndUpdateTrie() {
 	sleepForIfNoUpdate := time.Duration(int(viper.GetInt("zk-sleep-if-no-update"))) * time.Millisecond
+	var wg sync.WaitGroup
 	for {
 		zk.Lock()
 		nextOpAt := zk.consensus.LSN
-		shardId, err := zk.consensus.metadata.FetchShardId(nextOpAt)
+		gsn_shard_map := zk.consensus.metadata.FetchPendingShards(nextOpAt)
 
-		if err != nil {
-			log.Printf("[ Zookeeper ][ UpdateTrie ]No new update to apply; %v", err)
+		if len(gsn_shard_map) == 0 {
+			log.Printf("[ Zookeeper ][ UpdateTrie ]No new update to apply;")
 			time.Sleep(sleepForIfNoUpdate)
 			zk.Unlock()
 			continue
 		}
 
-		op, err := zk.consensus.ReadFromLog(nextOpAt, shardId)
-		if err != nil {
-			log.Printf("[ Zookeeper ][ UpdateTrie ]Reading operation from log failed for lsn: %v at sid: %v with error: %v", nextOpAt, shardId, err)
-			zk.Unlock()
-			continue
+		outputCh := make(chan GSN_OP_Pair, len(gsn_shard_map))
+
+		for gsn, shard := range gsn_shard_map {
+			wg.Add(1)
+
+			go func(gsn int64, shard int32) {
+				defer wg.Done()
+				op, err := zk.consensus.ReadFromLog(gsn, shard)
+				if err != nil {
+					log.Printf("[ Zookeeper ][ UpdateTrie ]Reading operation from log failed for lsn: %v at sid: %v with error: %v", gsn, shard, err)
+					zk.Unlock()
+					return
+				}
+				zk.consensus.metadata.UpdateEntryState(gsn)
+				if len(op) != 0 {
+					// Successfully fetched the operation, send it to the output channel
+					message := GSN_OP_Pair{GSN: gsn, op: op}
+					outputCh <- message
+				}
+			}(gsn, shard)
 		}
 
-		log.Printf("[ Zookeeper ][ UpdateTrie ]Updating trie with operation: %v", op)
-		zk.trie.Execute(op)
-		zk.consensus.metadata.UpdateEntryState(nextOpAt)
-		zk.consensus.IncrementLSN()
+		// goroutine to wait for all requests to finish
+		go func() {
+			wg.Wait()
+			close(outputCh)
+		}()
+		// Channels cannot be sorted so hold it in another var first
+		var pairs []GSN_OP_Pair
+		for pair := range outputCh {
+			pairs = append(pairs, pair)
+		}
+		// Sorting the slice by GSN - so that ops can be performed in-order
+		sort.Slice(pairs, func(i, j int) bool {
+			return pairs[i].GSN < pairs[j].GSN
+		})
+		for _, pair := range pairs {
+			log.Printf("[ Zookeeper ][ UpdateTrie ]Updating trie with operation: %v LSN: %v", pair.op, zk.consensus.LSN)
+			zk.trie.Execute(pair.op)
+			zk.consensus.IncrementLSN()
+		}
+
 		zk.Unlock()
-		time.Sleep(sleepForIfNoUpdate)
 	}
 }
 


### PR DESCRIPTION
CheckAndUpdateTrie now can parallelly get all the pending shards without synchronization and order them later to be applied to the trie